### PR TITLE
chore: update Dockerfile to install jq

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,8 @@ WORKDIR /app
 RUN apt-get update -y && \
   apt-get install build-essential -y && \
   apt-get install git -y && \
-  apt-get install curl -y
+  apt-get install curl -y && \
+  apt-get install jq -y 
 
 RUN apt-get install -y libgtk2.0-0 libgtk-3-0 libgbm-dev \
   libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 \


### PR DESCRIPTION
This PR fixes an issue where the backend container fails due to the `jq` binary not being found. The error was observed during the container startup process, particularly when running the `serve` script.

### Root Cause

The `jq` package was missing from the Docker image, which caused the following error during runtime:

```
/bin/sh: 1: jq: not found
Running without Temporal...
```

As a result, the application continued running without some functionality and eventually exited with code `0`.

### Fix

Updated the `Dockerfile` to include:

```Dockerfile
apt-get install jq -y
```

This ensures that `jq` is available in the container and prevents the runtime error.
