### PR TITLE
test: deploy rollout logs printing at GitHub Actions checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,11 @@ run-vulture:
 	cd src/apps/backend \
 		&& pipenv run vulture
 
-
+run-engine:
+	cd src/apps/backend \
+		&& pipenv run python --version \
+		&& pipenv run gunicorn -c gunicorn_config.py --reload server:app
+		
 run-temporal-server:
 	cd src/apps/backend \
 		&& PYTHONPATH=./ pipenv run python temporal_server.py

--- a/Makefile
+++ b/Makefile
@@ -23,10 +23,6 @@ run-vulture:
 	cd src/apps/backend \
 		&& pipenv run vulture
 
-run-engine:
-	cd src/apps/backend \
-		&& pipenv run python --version \
-		&& pipenv run gunicorn -c gunicorn_config.py --reload server:app
 
 run-temporal-server:
 	cd src/apps/backend \

--- a/lib/kube/scripts/post-deploy.sh
+++ b/lib/kube/scripts/post-deploy.sh
@@ -1,4 +1,45 @@
 #!/bin/bash
 
-kubectl rollout status deploy/"$KUBE_APP"-deployment -n "$KUBE_NS"
-kubectl rollout status deploy/"$KUBE_APP"-temporal-deployment -n "$KUBE_NS"
+DEPLOYMENTS=(
+  "${KUBE_APP}-deployment"
+  "${KUBE_APP}-temporal-deployment"
+)
+
+for DEPLOYMENT in "${DEPLOYMENTS[@]}"; do
+  echo " Waiting for deployment rollout: $DEPLOYMENT in $KUBE_NS..."
+
+  if ! kubectl rollout status deployment "$DEPLOYMENT" -n "$KUBE_NS" --timeout=100s; then
+    echo " Deployment rollout failed for $DEPLOYMENT"
+
+    echo " Getting label selector for $DEPLOYMENT"
+    selector=$(kubectl get deployment "$DEPLOYMENT" -n "$KUBE_NS" -o jsonpath='{.spec.selector.matchLabels}' | jq -r 'to_entries | map("\(.key)=\(.value)") | join(",")')
+
+    if [ -z "$selector" ]; then
+      echo "Could not extract label selector for $DEPLOYMENT — skipping log dump"
+      continue
+    fi
+
+    echo "Finding pods with selector: $selector"
+    pods=$(kubectl get pods -n "$KUBE_NS" -l "$selector" --field-selector=status.phase!=Running -o jsonpath='{.items[*].metadata.name}')
+
+    if [ -z "$pods" ]; then
+      echo "No failing pods found for $DEPLOYMENT"
+    else
+      for pod in $pods; do
+        echo -e "\nLogs for pod: $pod\n"
+
+        echo "::group::kubectl describe pod $pod"
+        kubectl describe pod "$pod" -n "$KUBE_NS" || echo "Failed to describe pod $pod"
+        echo "::endgroup::"
+
+        echo "::group::kubectl logs $pod --all-containers"
+        kubectl logs "$pod" -n "$KUBE_NS" --all-containers=true || echo "Failed to fetch logs for $pod"
+        echo "::endgroup::"
+      done
+    fi
+
+    exit 1
+  else
+    echo "$DEPLOYMENT successfully rolled out!"
+  fi
+done

--- a/lib/kube/scripts/post-deploy.sh
+++ b/lib/kube/scripts/post-deploy.sh
@@ -1,57 +1,58 @@
 #!/bin/bash
 
-DEPLOYMENTS=(
-  "${KUBE_APP}-deployment"
-  "${KUBE_APP}-temporal-deployment"
-)
-
+DEPLOYMENTS=("${KUBE_APP}-deployment" "${KUBE_APP}-temporal-deployment")
 FAILED_DEPLOYMENTS=()
 
+# Check rollout status
 for DEPLOYMENT in "${DEPLOYMENTS[@]}"; do
   echo "Waiting for deployment rollout: $DEPLOYMENT in $KUBE_NS..."
-
   if kubectl rollout status deployment "$DEPLOYMENT" -n "$KUBE_NS" --timeout=300s; then
     echo "Rollout successful for $DEPLOYMENT"
   else
-    echo "Rollout failed or stuck for $DEPLOYMENT"
+    echo "Rollout failed for $DEPLOYMENT"
     FAILED_DEPLOYMENTS+=("$DEPLOYMENT")
   fi
 done
 
-for DEPLOYMENT in "${FAILED_DEPLOYMENTS[@]}"; do
-  echo -e "\nChecking failed rollout for $DEPLOYMENT"
+# If any rollout failed, check logs and describe
+if [ "${#FAILED_DEPLOYMENTS[@]}" -ne 0 ]; then
+  for DEPLOYMENT in "${FAILED_DEPLOYMENTS[@]}"; do
+    echo -e "\nChecking failed rollout for $DEPLOYMENT"
+    echo "Getting label selector for $DEPLOYMENT..."
 
-  echo "Getting label selector for $DEPLOYMENT"
-  selector=$(kubectl get deployment "$DEPLOYMENT" -n "$KUBE_NS" -o jsonpath='{.spec.selector.matchLabels}' \
-    | jq -r 'to_entries | map("\(.key)=\(.value)") | join(",")')
+    selector=$(kubectl get deployment "$DEPLOYMENT" -n "$KUBE_NS" -o jsonpath='{.spec.selector.matchLabels}' \
+      | jq -r 'to_entries | map("\(.key)=\(.value)") | join(",")')
 
-  if [ -z "$selector" ]; then
-    echo "Could not extract label selector for $DEPLOYMENT — skipping log check"
-    continue
-  fi
+    if [ -z "$selector" ]; then
+      echo "Could not extract label selector for $DEPLOYMENT — skipping log check"
+      continue
+    fi
 
-  echo "Getting pods for $DEPLOYMENT"
-  pods=$(kubectl get pods -n "$KUBE_NS" -l "$selector" -o jsonpath='{.items[*].metadata.name}' | tr ' ' '\n' | sort -u)
+    echo "Getting pods for $DEPLOYMENT..."
+    pods=$(kubectl get pods -n "$KUBE_NS" -l "$selector" -o jsonpath='{.items[*].metadata.name}' | tr ' ' '\n' | sort -u)
 
-  if [ -z "$pods" ]; then
-    echo "No pods found for $DEPLOYMENT — possible issue with rollout"
-    continue
-  fi
+    if [ -z "$pods" ]; then
+      echo "No pods found for $DEPLOYMENT — possible issue with rollout"
+      continue
+    fi
 
-  for pod in $pods; do
-    echo -e "\nLogs for pod: $pod"
-
-    echo "::group::kubectl describe pod $pod"
-    kubectl describe pod "$pod" -n "$KUBE_NS" || echo "Failed to describe pod $pod"
-    echo "::endgroup::"
-
-    # Get container names from the pod
-    container_names=$(kubectl get pod "$pod" -n "$KUBE_NS" -o json | jq -r '.spec.containers[].name')
-
-    for container in $container_names; do
-      echo "::group::Logs for container $container in pod $pod"
-      kubectl logs "$pod" -n "$KUBE_NS" -c "$container" --tail=-1 || echo "Failed to fetch logs for container $container in $pod"
+    for pod in $pods; do
+      echo -e "\nLogs for pod: $pod"
+      echo "::group::kubectl describe pod $pod"
+      kubectl describe pod "$pod" -n "$KUBE_NS" || echo "Failed to describe pod $pod"
       echo "::endgroup::"
+
+      container_names=$(kubectl get pod "$pod" -n "$KUBE_NS" -o json | jq -r '.spec.containers[].name')
+      for container in $container_names; do
+        echo "::group::Logs for container $container in pod $pod"
+        kubectl logs "$pod" -n "$KUBE_NS" -c "$container" --tail=-1 || echo "Failed to fetch logs for container $container in $pod"
+        echo "::endgroup::"
+      done
     done
   done
-done
+
+  echo "One or more deployments failed rollout. Exiting with error."
+  exit 1
+fi
+
+echo "Deployment finished successfully"

--- a/lib/kube/scripts/post-deploy.sh
+++ b/lib/kube/scripts/post-deploy.sh
@@ -8,7 +8,7 @@ DEPLOYMENTS=(
 for DEPLOYMENT in "${DEPLOYMENTS[@]}"; do
   echo "Waiting for deployment rollout: $DEPLOYMENT in $KUBE_NS..."
 
-  if kubectl rollout status deployment "$DEPLOYMENT" -n "$KUBE_NS"; then
+  if kubectl rollout status deployment "$DEPLOYMENT" -n "$KUBE_NS" --timeout=300s; then
     echo "Rollout successful for $DEPLOYMENT"
   else
     echo "Rollout failed or stuck for $DEPLOYMENT — checking pod logs"

--- a/lib/kube/scripts/post-deploy.sh
+++ b/lib/kube/scripts/post-deploy.sh
@@ -6,24 +6,25 @@ DEPLOYMENTS=(
 )
 
 for DEPLOYMENT in "${DEPLOYMENTS[@]}"; do
-  echo " Waiting for deployment rollout: $DEPLOYMENT in $KUBE_NS..."
+  echo "Waiting for deployment rollout: $DEPLOYMENT in $KUBE_NS..."
 
-  if ! kubectl rollout status deployment "$DEPLOYMENT" -n "$KUBE_NS" --timeout=100s; then
-    echo " Deployment rollout failed for $DEPLOYMENT"
+  if kubectl rollout status deployment "$DEPLOYMENT" -n "$KUBE_NS"; then
+    echo "Rollout successful for $DEPLOYMENT"
+  else
+    echo "Rollout failed or stuck for $DEPLOYMENT — checking pod logs"
 
-    echo " Getting label selector for $DEPLOYMENT"
+    echo "Getting label selector for $DEPLOYMENT"
     selector=$(kubectl get deployment "$DEPLOYMENT" -n "$KUBE_NS" -o jsonpath='{.spec.selector.matchLabels}' | jq -r 'to_entries | map("\(.key)=\(.value)") | join(",")')
 
     if [ -z "$selector" ]; then
-      echo "Could not extract label selector for $DEPLOYMENT — skipping log dump"
+      echo "Could not extract label selector for $DEPLOYMENT — skipping log check"
       continue
     fi
 
-    echo "Finding pods with selector: $selector"
-    pods=$(kubectl get pods -n "$KUBE_NS" -l "$selector" --field-selector=status.phase!=Running -o jsonpath='{.items[*].metadata.name}')
+    pods=$(kubectl get pods -n "$KUBE_NS" -l "$selector" --field-selector=status.phase!=Running -o jsonpath='{.items[*].metadata.name}' | tr ' ' '\n')
 
     if [ -z "$pods" ]; then
-      echo "No failing pods found for $DEPLOYMENT"
+      echo "No failing pods found for $DEPLOYMENT — rollout issue might be unrelated to pod status."
     else
       for pod in $pods; do
         echo -e "\nLogs for pod: $pod\n"
@@ -37,9 +38,5 @@ for DEPLOYMENT in "${DEPLOYMENTS[@]}"; do
         echo "::endgroup::"
       done
     fi
-
-    exit 1
-  else
-    echo "$DEPLOYMENT successfully rolled out!"
   fi
 done

--- a/lib/kube/scripts/post-deploy.sh
+++ b/lib/kube/scripts/post-deploy.sh
@@ -1,58 +1,44 @@
 #!/bin/bash
 
-DEPLOYMENTS=("${KUBE_APP}-deployment" "${KUBE_APP}-temporal-deployment")
+set -e
+
+echo "deploy :: running post deploy hook - app/lib/kube/scripts/post-deploy.sh"
+
+DEPLOYMENTS=$(kubectl get deployments -n "$KUBE_NS" -l app.kubernetes.io/instance="$KUBE_APP" -o json | jq -r '.items[].metadata.name')
+
 FAILED_DEPLOYMENTS=()
 
-# Check rollout status
-for DEPLOYMENT in "${DEPLOYMENTS[@]}"; do
+for DEPLOYMENT in $DEPLOYMENTS; do
   echo "Waiting for deployment rollout: $DEPLOYMENT in $KUBE_NS..."
-  if kubectl rollout status deployment "$DEPLOYMENT" -n "$KUBE_NS" --timeout=300s; then
-    echo "Rollout successful for $DEPLOYMENT"
-  else
+  if ! kubectl rollout status deployment "$DEPLOYMENT" -n "$KUBE_NS" --timeout=60s; then
     echo "Rollout failed for $DEPLOYMENT"
     FAILED_DEPLOYMENTS+=("$DEPLOYMENT")
   fi
 done
 
-# If any rollout failed, check logs and describe
-if [ "${#FAILED_DEPLOYMENTS[@]}" -ne 0 ]; then
-  for DEPLOYMENT in "${FAILED_DEPLOYMENTS[@]}"; do
-    echo -e "\nChecking failed rollout for $DEPLOYMENT"
-    echo "Getting label selector for $DEPLOYMENT..."
-
-    selector=$(kubectl get deployment "$DEPLOYMENT" -n "$KUBE_NS" -o jsonpath='{.spec.selector.matchLabels}' \
-      | jq -r 'to_entries | map("\(.key)=\(.value)") | join(",")')
-
-    if [ -z "$selector" ]; then
-      echo "Could not extract label selector for $DEPLOYMENT — skipping log check"
-      continue
-    fi
-
-    echo "Getting pods for $DEPLOYMENT..."
-    pods=$(kubectl get pods -n "$KUBE_NS" -l "$selector" -o jsonpath='{.items[*].metadata.name}' | tr ' ' '\n' | sort -u)
-
-    if [ -z "$pods" ]; then
-      echo "No pods found for $DEPLOYMENT — possible issue with rollout"
-      continue
-    fi
-
-    for pod in $pods; do
-      echo -e "\nLogs for pod: $pod"
-      echo "::group::kubectl describe pod $pod"
-      kubectl describe pod "$pod" -n "$KUBE_NS" || echo "Failed to describe pod $pod"
-      echo "::endgroup::"
-
-      container_names=$(kubectl get pod "$pod" -n "$KUBE_NS" -o json | jq -r '.spec.containers[].name')
-      for container in $container_names; do
-        echo "::group::Logs for container $container in pod $pod"
-        kubectl logs "$pod" -n "$KUBE_NS" -c "$container" --tail=-1 || echo "Failed to fetch logs for container $container in $pod"
-        echo "::endgroup::"
-      done
-    done
-  done
-
-  echo "One or more deployments failed rollout. Exiting with error."
-  exit 1
+if [ ${#FAILED_DEPLOYMENTS[@]} -eq 0 ]; then
+  echo "Deployment finished successfully"
+  exit 0
 fi
 
-echo "Deployment finished successfully"
+for DEPLOYMENT in "${FAILED_DEPLOYMENTS[@]}"; do
+  echo "Checking failed rollout for $DEPLOYMENT"
+
+  PODS=$(kubectl get pods -n "$KUBE_NS" -l app.kubernetes.io/name="$DEPLOYMENT" -o jsonpath='{.items[*].metadata.name}')
+
+  if [ -z "$PODS" ]; then
+    echo "No pods found for deployment $DEPLOYMENT"
+    continue
+  fi
+
+  for POD in $PODS; do
+    echo "kubectl describe pod $POD -n $KUBE_NS"
+    kubectl describe pod "$POD" -n "$KUBE_NS"
+
+    echo "Logs for pod: $POD"
+    kubectl logs "$POD" -n "$KUBE_NS"
+  done
+done
+
+echo "One or more deployments failed rollout. Exiting with error."
+exit 1

--- a/lib/kube/scripts/post-deploy.sh
+++ b/lib/kube/scripts/post-deploy.sh
@@ -5,38 +5,47 @@ DEPLOYMENTS=(
   "${KUBE_APP}-temporal-deployment"
 )
 
+FAILED_DEPLOYMENTS=()
+
 for DEPLOYMENT in "${DEPLOYMENTS[@]}"; do
   echo "Waiting for deployment rollout: $DEPLOYMENT in $KUBE_NS..."
 
   if kubectl rollout status deployment "$DEPLOYMENT" -n "$KUBE_NS" --timeout=300s; then
     echo "Rollout successful for $DEPLOYMENT"
   else
-    echo "Rollout failed or stuck for $DEPLOYMENT — checking pod logs"
+    echo "Rollout failed or stuck for $DEPLOYMENT"
+    FAILED_DEPLOYMENTS+=("$DEPLOYMENT")
+  fi
+done
 
-    echo "Getting label selector for $DEPLOYMENT"
-    selector=$(kubectl get deployment "$DEPLOYMENT" -n "$KUBE_NS" -o jsonpath='{.spec.selector.matchLabels}' | jq -r 'to_entries | map("\(.key)=\(.value)") | join(",")')
+for DEPLOYMENT in "${FAILED_DEPLOYMENTS[@]}"; do
+  echo -e "\nChecking failed rollout for $DEPLOYMENT"
 
-    if [ -z "$selector" ]; then
-      echo "Could not extract label selector for $DEPLOYMENT — skipping log check"
-      continue
-    fi
+  echo "Getting label selector for $DEPLOYMENT"
+  selector=$(kubectl get deployment "$DEPLOYMENT" -n "$KUBE_NS" -o jsonpath='{.spec.selector.matchLabels}' \
+    | jq -r 'to_entries | map("\(.key)=\(.value)") | join(",")')
 
-    pods=$(kubectl get pods -n "$KUBE_NS" -l "$selector" --field-selector=status.phase!=Running -o jsonpath='{.items[*].metadata.name}' | tr ' ' '\n')
+  if [ -z "$selector" ]; then
+    echo "Could not extract label selector for $DEPLOYMENT — skipping log check"
+    continue
+  fi
 
-    if [ -z "$pods" ]; then
-      echo "No failing pods found for $DEPLOYMENT — rollout issue might be unrelated to pod status."
-    else
-      for pod in $pods; do
-        echo -e "\nLogs for pod: $pod\n"
+  pods=$(kubectl get pods -n "$KUBE_NS" -l "$selector" --field-selector=status.phase!=Running \
+    -o jsonpath='{.items[*].metadata.name}' | tr ' ' '\n')
 
-        echo "::group::kubectl describe pod $pod"
-        kubectl describe pod "$pod" -n "$KUBE_NS" || echo "Failed to describe pod $pod"
-        echo "::endgroup::"
+  if [ -z "$pods" ]; then
+    echo "No failing pods found for $DEPLOYMENT — rollout issue might be unrelated to pod status."
+  else
+    for pod in $pods; do
+      echo -e "\nLogs for pod: $pod"
 
-        echo "::group::kubectl logs $pod --all-containers"
-        kubectl logs "$pod" -n "$KUBE_NS" --all-containers=true || echo "Failed to fetch logs for $pod"
-        echo "::endgroup::"
-      done
-    fi
+      echo "::group::kubectl describe pod $pod"
+      kubectl describe pod "$pod" -n "$KUBE_NS" || echo "Failed to describe pod $pod"
+      echo "::endgroup::"
+
+      echo "::group::kubectl logs $pod --all-containers"
+      kubectl logs "$pod" -n "$KUBE_NS" --all-containers=true || echo "Failed to fetch logs for $pod"
+      echo "::endgroup::"
+    done
   fi
 done

--- a/lib/kube/scripts/post-deploy.sh
+++ b/lib/kube/scripts/post-deploy.sh
@@ -19,11 +19,10 @@ ROLL_OUT_SUCCESS=true
 # Function to collect logs from a deployment using label filters
 collect_logs_from_deployment() {
   local DEPLOYMENT_NAME=$1
-  local COMPONENT=$2
 
-  echo -e "\nFetching pods for: $DEPLOYMENT_NAME (component=$COMPONENT)"
+  echo -e "\nFetching pods for: $DEPLOYMENT_NAME"
 
-  PODS=$(kubectl get pods -n "$KUBE_NS" -l "app=$KUBE_APP,component=$COMPONENT" \
+  PODS=$(kubectl get pods -n "$KUBE_NS" -l "app=$KUBE_APP" \
     --field-selector=status.phase!=Succeeded \
     -o jsonpath='{.items[*].metadata.name}')
 
@@ -45,12 +44,11 @@ collect_logs_from_deployment() {
 # Function to wait for rollout and fetch logs if it fails
 wait_for_rollout() {
   local DEPLOYMENT_NAME=$1
-  local COMPONENT=$2
 
   echo "Waiting for rollout of $DEPLOYMENT_NAME"
   if ! kubectl rollout status deploy/"$DEPLOYMENT_NAME" -n "$KUBE_NS"; then
     echo "Rollout failed for $DEPLOYMENT_NAME"
-    collect_logs_from_deployment "$DEPLOYMENT_NAME" "$COMPONENT"
+    collect_logs_from_deployment "$DEPLOYMENT_NAME"
     ROLL_OUT_SUCCESS=false
   fi
 }

--- a/lib/kube/scripts/post-deploy.sh
+++ b/lib/kube/scripts/post-deploy.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-
 set -e
 
 echo "Deployment rollout status for $KUBE_APP in namespace $KUBE_NS"
@@ -17,16 +16,19 @@ TEMPORAL_DEPLOYMENT="$KUBE_APP-temporal-deployment"
 # Track rollout success state
 ROLL_OUT_SUCCESS=true
 
-# Function to collect logs from a deployment
+# Function to collect logs from a deployment using label filters
 collect_logs_from_deployment() {
   local DEPLOYMENT_NAME=$1
-  echo -e "\nFetching pods for: $DEPLOYMENT_NAME"
+  local COMPONENT=$2
 
-  PODS=$(kubectl get pods -n "$KUBE_NS" -o json \
-    | jq -r --arg name "$DEPLOYMENT_NAME" '.items[] | select(.metadata.ownerReferences[].name == $name) | .metadata.name')
+  echo -e "\nFetching pods for: $DEPLOYMENT_NAME (component=$COMPONENT)"
+
+  PODS=$(kubectl get pods -n "$KUBE_NS" -l "app=$KUBE_APP,component=$COMPONENT" \
+    --field-selector=status.phase!=Succeeded \
+    -o jsonpath='{.items[*].metadata.name}')
 
   if [[ -z "$PODS" ]]; then
-    echo "No pods found for: $DEPLOYMENT_NAME"
+    echo "No active pods found for: $DEPLOYMENT_NAME"
     return
   fi
 
@@ -34,32 +36,34 @@ collect_logs_from_deployment() {
     echo -e "\nLogs from pod: $pod"
     containers=$(kubectl get pod "$pod" -n "$KUBE_NS" -o jsonpath='{.spec.containers[*].name}')
     for container in $containers; do
-      echo "Container: $container"
-      kubectl logs "$pod" -c "$container" -n "$KUBE_NS" || echo "Failed to get logs for $container"
+      echo -e "\nContainer: $container"
+      kubectl logs "$pod" -c "$container" -n "$KUBE_NS" --tail=100 || echo "Failed to get logs for $container"
     done
   done
 }
 
-# Function to wait for rollout and collect logs if failed
+# Function to wait for rollout and fetch logs if it fails
 wait_for_rollout() {
   local DEPLOYMENT_NAME=$1
+  local COMPONENT=$2
+
   echo "Waiting for rollout of $DEPLOYMENT_NAME"
   if ! kubectl rollout status deploy/"$DEPLOYMENT_NAME" -n "$KUBE_NS"; then
     echo "Rollout failed for $DEPLOYMENT_NAME"
-    collect_logs_from_deployment "$DEPLOYMENT_NAME"  # <-- Print logs immediately on failure
+    collect_logs_from_deployment "$DEPLOYMENT_NAME" "$COMPONENT"
     ROLL_OUT_SUCCESS=false
   fi
 }
 
-# Run rollouts (logs on failure printed inline)
+# Wait for rollout and capture logs on failure
 wait_for_rollout "$WEB_DEPLOYMENT"
 wait_for_rollout "$TEMPORAL_DEPLOYMENT"
 
-# Optional: Collect logs again even if rollouts succeeded (for audit/debug)
+# Always collect logs at the end (useful for audit/debug)
 collect_logs_from_deployment "$WEB_DEPLOYMENT"
 collect_logs_from_deployment "$TEMPORAL_DEPLOYMENT"
 
-# Final status
+# Exit based on rollout success
 if [ "$ROLL_OUT_SUCCESS" = true ]; then
   echo -e "\nAll deployments rolled out successfully"
 else

--- a/lib/kube/scripts/post-deploy.sh
+++ b/lib/kube/scripts/post-deploy.sh
@@ -4,26 +4,29 @@ set -e
 
 echo "Deployment rollout status for $KUBE_APP in namespace $KUBE_NS"
 
-# Ensure required env vars are set
+
 if [[ -z "$KUBE_APP" || -z "$KUBE_NS" ]]; then
   echo "KUBE_APP or KUBE_NS is not set."
   exit 1
 fi
 
-# Set deployment names
 WEB_DEPLOYMENT="$KUBE_APP-deployment"
 TEMPORAL_DEPLOYMENT="$KUBE_APP-temporal-deployment"
 
-# Wait for both rollouts to complete
-echo "Waiting for rollout of $WEB_DEPLOYMENT and $TEMPORAL_DEPLOYMENT"
-kubectl rollout status deploy/"$WEB_DEPLOYMENT" -n "$KUBE_NS"
-kubectl rollout status deploy/"$TEMPORAL_DEPLOYMENT" -n "$KUBE_NS"
+# Function to wait for rollout and handle failure gracefully
+wait_for_rollout() {
+  local DEPLOYMENT_NAME=$1
+  echo "Waiting for rollout of $DEPLOYMENT_NAME"
+  if ! kubectl rollout status deploy/"$DEPLOYMENT_NAME" -n "$KUBE_NS"; then
+    echo "⚠️ Rollout failed or timed out for $DEPLOYMENT_NAME. Continuing to collect logs..."
+  fi
+}
 
 # Function to collect logs from a deployment
 collect_logs_from_deployment() {
   local DEPLOYMENT_NAME=$1
-  echo "Fetching pods for: $DEPLOYMENT_NAME"
-  
+  echo -e "\nFetching pods for: $DEPLOYMENT_NAME"
+
   PODS=$(kubectl get pods -n "$KUBE_NS" -l "app.kubernetes.io/name=$DEPLOYMENT_NAME" -o name)
 
   if [[ -z "$PODS" ]]; then
@@ -35,14 +38,18 @@ collect_logs_from_deployment() {
     echo -e "\nLogs from pod: $pod"
     containers=$(kubectl get "$pod" -n "$KUBE_NS" -o jsonpath='{.spec.containers[*].name}')
     for container in $containers; do
-      echo "Container: $container"
-      kubectl logs "$pod" -c "$container" -n "$KUBE_NS" || echo "Failed to get logs for $container"
+      echo "🔹 Container: $container"
+      kubectl logs "$pod" -c "$container" -n "$KUBE_NS" || echo "⚠️ Failed to get logs for $container"
     done
   done
 }
+
+# Wait for rollouts without exiting on failure
+wait_for_rollout "$WEB_DEPLOYMENT"
+wait_for_rollout "$TEMPORAL_DEPLOYMENT"
 
 # Collect logs from both deployments
 collect_logs_from_deployment "$WEB_DEPLOYMENT"
 collect_logs_from_deployment "$TEMPORAL_DEPLOYMENT"
 
-echo -e "\n Deployment finished successfully"
+echo -e "\nPost-deployment rollout and log collection complete."


### PR DESCRIPTION
## Description

This PR improves the `post-deploy.sh` script to enhance debugging visibility during deployment rollouts in CI. It ensures engineers immediately see relevant logs and pod-level issues directly in the GitHub Actions output, making CI failures more actionable and less dependent on DevOps intervention.

## Why this change is needed

Previously, when a deployment failed (e.g., due to image pull errors or container crashes), the CI job simply reported that the rollout exceeded the progress deadline without showing any underlying reason. Developers had to ask DevOps to manually inspect cluster logs, delaying root cause discovery and slowing down the feedback loop.

## What this PR changes

- Refactors the `post-deploy.sh` script to:
  - Wait for rollout completion of both `web-deployment` and `temporal-deployment`
  - Detect rollout failures and immediately fetch logs from related pods
  - Improve pod log fetching logic by:
    - Deriving pods based on `matchLabels` from the failed deployment
    - Listing all related pods and filtering out completed jobs
    - Printing `kubectl logs` for each container in each pod
- Ensures pods are filtered using `app=$KUBE_APP` for PR-specific isolation, and avoids duplicate or irrelevant logs

## How this helps

- Provides immediate, detailed failure information in the CI output (no cluster access required)
- Displays error logs from each container in non-running pods directly in the deploy job
- Enables engineers to debug rollout failures independently and unblock themselves faster
- Reduces dependency on DevOps and minimizes friction in the CI/CD pipeline


## Tests

<img width="974" height="374" alt="Screenshot 1" src="https://github.com/user-attachments/assets/f2571c7a-52c2-4870-846f-6577a3aa162d" />