### PR TITLE
chore: update reusable workflow references to github-ci v3.2

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,107 @@
+## Configuring Cloud Provider for CI/CD Workflows
+
+This project supports deployment and cleanup on **both DigitalOcean and AWS** using GitHub Actions.  
+You can easily switch the cloud provider for any environment by updating the `hosting_provider` input in the workflow files.
+
+---
+
+### How to Select the Cloud Provider
+
+Each workflow file (such as `.github/workflows/production_on_push.yml`, `.github/workflows/preview_on_dispatch.yml`, `.github/workflows/clean_on_delete.yml`, etc.) contains a `hosting_provider` input.  
+
+Set this value to choose your cloud provider:
+
+- For **DigitalOcean**:  
+  `hosting_provider: DIGITAL_OCEAN`
+- For **AWS**:  
+  `hosting_provider: AWS`
+
+You can pass the `hosting_provider` value:
+- **Directly** in the workflow `with:` block
+- Or define it globally using **repository/environment variables** for easier management
+
+**Example for DigitalOcean:**
+```yaml
+with:
+  hosting_provider: DIGITAL_OCEAN
+  # ...other inputs...
+secrets:
+  do_access_token: ${{ secrets.DO_ACCESS_TOKEN }}
+  # ...other secrets...
+```
+
+**Example for AWS:**
+```yaml
+with:
+  hosting_provider: AWS
+  aws_cluster_name: <your-eks-cluster-name>
+  aws_region: <your-aws-region>
+  # ...other inputs...
+secrets:
+  aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  # ...other secrets...
+```
+
+---
+
+### Required Inputs and Secrets
+
+#### For DigitalOcean:
+- **Inputs:**  
+  - `do_cluster_id`
+- **Secrets:**  
+  - `do_access_token`
+
+#### For AWS:
+- **Inputs:**  
+  - `aws_cluster_name`
+  - `aws_region`
+- **Secrets:**  
+  - `aws_access_key_id`
+  - `aws_secret_access_key`
+
+---
+
+### Steps to Change the Cloud Provider
+
+1. **Open the workflow file** you want to update (e.g., `production_on_push.yml`).
+2. **Change the value of `hosting_provider`** to either `DIGITAL_OCEAN` or `AWS`.
+3. **Add or update the required inputs and secrets** for your chosen provider.
+4. **Remove or comment out** any inputs/secrets not needed for your selected provider (optional, for clarity).
+5. **Commit and push** your changes.
+
+---
+
+### Example: Switching from DigitalOcean to AWS
+
+**Before (DigitalOcean):**
+```yaml
+with:
+  hosting_provider: DIGITAL_OCEAN
+  do_cluster_id: ${{ vars.DO_CLUSTER_ID }}
+secrets:
+  do_access_token: ${{ secrets.DO_ACCESS_TOKEN }}
+```
+
+**After (AWS):**
+```yaml
+with:
+  hosting_provider: AWS
+  aws_cluster_name: <your-eks-cluster-name>
+  aws_region: <your-aws-region>
+secrets:
+  aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+```
+
+---
+
+### Notes
+
+- The value for `hosting_provider` is **case-sensitive** and must match what the workflow expects.
+- Make sure the required secrets are added in your GitHub repository settings under **Settings → Secrets and variables → Actions**.
+- If you are using AWS, ensure your EKS cluster and IAM credentials are set up correctly.
+- If you are using DigitalOcean, ensure your Kubernetes cluster and API token are set up correctly.
+
+---

--- a/.github/workflows/clean_on_delete.yml
+++ b/.github/workflows/clean_on_delete.yml
@@ -5,7 +5,7 @@ on: delete
 jobs:
   clean:
     if: github.event.ref_type == 'branch'
-    uses: jalantechnologies/github-ci/.github/workflows/clean.yml@v3.1
+    uses: jalantechnologies/github-ci/.github/workflows/clean.yml@v3.2
     concurrency:
       group: ci-preview-${{ github.event.ref }}
       cancel-in-progress: true

--- a/.github/workflows/clean_on_delete.yml
+++ b/.github/workflows/clean_on_delete.yml
@@ -4,19 +4,24 @@ on: delete
 
 jobs:
   clean:
-    # only run when deleting a branch
     if: github.event.ref_type == 'branch'
     uses: jalantechnologies/github-ci/.github/workflows/clean.yml@v3.1
     concurrency:
       group: ci-preview-${{ github.event.ref }}
       cancel-in-progress: true
     with:
+      # ENV-BASED provider selection
+      hosting_provider: ${{ vars.HOSTING_PROVIDER }}  # 'DIGITAL_OCEAN' or 'AWS'
       app_name: frm-boilerplate
       app_env: preview
       branch: ${{ github.event.ref }}
       docker_registry: ${{ vars.DOCKER_REGISTRY }}
       docker_username: ${{ vars.DOCKER_USERNAME }}
+      aws_cluster_name: ${{ vars.AWS_CLUSTER_NAME }}
+      aws_region: ${{ vars.AWS_REGION }}
       do_cluster_id: ${{ vars.DO_CLUSTER_ID }}
     secrets:
       docker_password: ${{ secrets.DOCKER_PASSWORD }}
+      aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       do_access_token: ${{ secrets.DO_ACCESS_TOKEN }}

--- a/.github/workflows/clean_on_dispatch.yml
+++ b/.github/workflows/clean_on_dispatch.yml
@@ -4,7 +4,7 @@ on: workflow_dispatch
 
 jobs:
   clean:
-    uses: jalantechnologies/github-ci/.github/workflows/clean.yml@v3.1
+    uses: jalantechnologies/github-ci/.github/workflows/clean.yml@v3.2
     concurrency:
       group: ci-preview-${{ github.event.ref }}
       cancel-in-progress: true

--- a/.github/workflows/clean_on_dispatch.yml
+++ b/.github/workflows/clean_on_dispatch.yml
@@ -9,12 +9,17 @@ jobs:
       group: ci-preview-${{ github.event.ref }}
       cancel-in-progress: true
     with:
+      hosting_provider: ${{ vars.HOSTING_PROVIDER }} # 'DIGITAL_OCEAN' or 'AWS'
       app_name: frm-boilerplate
       app_env: preview
       branch: ${{ github.event.ref }}
       docker_registry: ${{ vars.DOCKER_REGISTRY }}
       docker_username: ${{ vars.DOCKER_USERNAME }}
+      aws_cluster_name: ${{ vars.AWS_CLUSTER_NAME }}
+      aws_region: ${{ vars.AWS_REGION }}
       do_cluster_id: ${{ vars.DO_CLUSTER_ID }}
     secrets:
       docker_password: ${{ secrets.DOCKER_PASSWORD }}
+      aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       do_access_token: ${{ secrets.DO_ACCESS_TOKEN }}

--- a/.github/workflows/clean_on_pr_closed.yml
+++ b/.github/workflows/clean_on_pr_closed.yml
@@ -11,12 +11,17 @@ jobs:
       group: ci-preview-${{ github.event.pull_request.head.ref }}
       cancel-in-progress: true
     with:
+      hosting_provider: ${{ vars.HOSTING_PROVIDER }} # 'DIGITAL_OCEAN' or 'AWS'
       app_name: frm-boilerplate
       app_env: preview
       branch: ${{ github.event.pull_request.head.ref }}
       docker_registry: ${{ vars.DOCKER_REGISTRY }}
       docker_username: ${{ vars.DOCKER_USERNAME }}
+      aws_cluster_name: ${{ vars.AWS_CLUSTER_NAME }}
+      aws_region: ${{ vars.AWS_REGION }}
       do_cluster_id: ${{ vars.DO_CLUSTER_ID }}
     secrets:
       docker_password: ${{ secrets.DOCKER_PASSWORD }}
+      aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       do_access_token: ${{ secrets.DO_ACCESS_TOKEN }}

--- a/.github/workflows/clean_on_pr_closed.yml
+++ b/.github/workflows/clean_on_pr_closed.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   clean:
-    uses: jalantechnologies/github-ci/.github/workflows/clean.yml@v3.1
+    uses: jalantechnologies/github-ci/.github/workflows/clean.yml@v3.2
     concurrency:
       group: ci-preview-${{ github.event.pull_request.head.ref }}
       cancel-in-progress: true

--- a/.github/workflows/preview_on_dispatch.yml
+++ b/.github/workflows/preview_on_dispatch.yml
@@ -4,7 +4,7 @@ on: workflow_dispatch
 
 jobs:
   preview:
-    uses: jalantechnologies/github-ci/.github/workflows/ci.yml@v3.1
+    uses: jalantechnologies/github-ci/.github/workflows/ci.yml@v3.2
     concurrency:
       group: ci-preview-${{ github.event.ref }}
       cancel-in-progress: true

--- a/.github/workflows/preview_on_dispatch.yml
+++ b/.github/workflows/preview_on_dispatch.yml
@@ -9,6 +9,7 @@ jobs:
       group: ci-preview-${{ github.event.ref }}
       cancel-in-progress: true
     with:
+      hosting_provider: ${{ vars.HOSTING_PROVIDER }} # 'DIGITAL_OCEAN' or 'AWS'
       app_name: frm-boilerplate
       app_env: preview
       app_hostname: '{1}.preview.platform.bettrhq.com'
@@ -17,8 +18,12 @@ jobs:
         APP_ENV=preview
       docker_registry: ${{ vars.DOCKER_REGISTRY }}
       docker_username: ${{ vars.DOCKER_USERNAME }}
+      aws_cluster_name: ${{ vars.AWS_CLUSTER_NAME }}
+      aws_region: ${{ vars.AWS_REGION }}
       do_cluster_id: ${{ vars.DO_CLUSTER_ID }}
     secrets:
       docker_password: ${{ secrets.DOCKER_PASSWORD }}
       doppler_token: ${{ secrets.DOPPLER_PREVIEW_TOKEN }}
+      aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       do_access_token: ${{ secrets.DO_ACCESS_TOKEN }}

--- a/.github/workflows/preview_on_pr_update.yml
+++ b/.github/workflows/preview_on_pr_update.yml
@@ -8,7 +8,7 @@ jobs:
   preview:
     # only run when updating an 'Open' PR
     if: github.event.pull_request.state == 'open'
-    uses: jalantechnologies/github-ci/.github/workflows/ci.yml@v3.1
+    uses: jalantechnologies/github-ci/.github/workflows/ci.yml@v3.2
     concurrency:
       group: ci-preview-${{ github.event.pull_request.head.ref }}
       cancel-in-progress: true

--- a/.github/workflows/preview_on_pr_update.yml
+++ b/.github/workflows/preview_on_pr_update.yml
@@ -13,6 +13,7 @@ jobs:
       group: ci-preview-${{ github.event.pull_request.head.ref }}
       cancel-in-progress: true
     with:
+      hosting_provider: ${{ vars.HOSTING_PROVIDER }} # 'DIGITAL_OCEAN' or 'AWS'
       analyze_base: main
       app_name: frm-boilerplate
       app_env: preview
@@ -23,11 +24,15 @@ jobs:
       checks: "['npm:coverage', 'npm:lint', 'compose:test']"
       docker_registry: ${{ vars.DOCKER_REGISTRY }}
       docker_username: ${{ vars.DOCKER_USERNAME }}
+      aws_cluster_name: ${{ vars.AWS_CLUSTER_NAME }}
+      aws_region: ${{ vars.AWS_REGION }}
       pull_request_number: ${{ github.event.number }}
       sonar_host_url: ${{ vars.SONAR_HOST_URL }}
       do_cluster_id: ${{ vars.DO_CLUSTER_ID }}
     secrets:
       docker_password: ${{ secrets.DOCKER_PASSWORD }}
       doppler_token: ${{ secrets.DOPPLER_PREVIEW_TOKEN }}
+      aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       do_access_token: ${{ secrets.DO_ACCESS_TOKEN }}
       sonar_token: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/production_on_push.yml
+++ b/.github/workflows/production_on_push.yml
@@ -12,6 +12,7 @@ jobs:
       group: ci-production-${{ github.event.ref }}
       cancel-in-progress: true
     with:
+      hosting_provider: ${{ vars.HOSTING_PROVIDER }} # 'DIGITAL_OCEAN' or 'AWS'
       app_name: frm-boilerplate
       app_env: production
       app_hostname: flask-react-template.platform.bettrhq.com
@@ -19,10 +20,14 @@ jobs:
       checks: "['npm:coverage', 'npm:lint', 'compose:test']"
       docker_registry: ${{ vars.DOCKER_REGISTRY }}
       docker_username: ${{ vars.DOCKER_USERNAME }}
+      aws_cluster_name: ${{ vars.AWS_CLUSTER_NAME }}
+      aws_region: ${{ vars.AWS_REGION }}
       sonar_host_url: ${{ vars.SONAR_HOST_URL }}
       do_cluster_id: ${{ vars.DO_CLUSTER_ID }}
     secrets:
       docker_password: ${{ secrets.DOCKER_PASSWORD }}
       doppler_token: ${{ secrets.DOPPLER_PRODUCTION_TOKEN }}
+      aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       do_access_token: ${{ secrets.DO_ACCESS_TOKEN }}
       sonar_token: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/production_on_push.yml
+++ b/.github/workflows/production_on_push.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   production:
-    uses: jalantechnologies/github-ci/.github/workflows/ci.yml@v3.1
+    uses: jalantechnologies/github-ci/.github/workflows/ci.yml@v3.2
     concurrency:
       group: ci-production-${{ github.event.ref }}
       cancel-in-progress: true


### PR DESCRIPTION
### Summary
This PR updates all GitHub Actions workflow files to reference the latest `v3.2` release of the `jalantechnologies/github-ci` reusable workflow.

### Why this change?
- To take advantage of recent enhancements introduced in `v3.2`, including:
  - Improved dashboard URL formatting
  - Additional inputs like `hosting_provider` and environment-specific configs
  - General improvements and consistency across environments

### Impact
- All CI/CD pipelines (preview, production, cleanup) will now use the updated logic and configurations from `v3.2`
- Ensures compatibility with the latest deployment patterns and dashboard formatting