### PR TITLE
chore: update reusable workflow references to github-ci v3.2

### DIFF
--- a/.github/workflows/clean_on_delete.yml
+++ b/.github/workflows/clean_on_delete.yml
@@ -5,7 +5,7 @@ on: delete
 jobs:
   clean:
     if: github.event.ref_type == 'branch'
-    uses: jalantechnologies/github-ci/.github/workflows/clean.yml@v3.1
+    uses: jalantechnologies/github-ci/.github/workflows/clean.yml@v3.2
     concurrency:
       group: ci-preview-${{ github.event.ref }}
       cancel-in-progress: true

--- a/.github/workflows/clean_on_dispatch.yml
+++ b/.github/workflows/clean_on_dispatch.yml
@@ -4,7 +4,7 @@ on: workflow_dispatch
 
 jobs:
   clean:
-    uses: jalantechnologies/github-ci/.github/workflows/clean.yml@v3.1
+    uses: jalantechnologies/github-ci/.github/workflows/clean.yml@v3.2
     concurrency:
       group: ci-preview-${{ github.event.ref }}
       cancel-in-progress: true

--- a/.github/workflows/clean_on_pr_closed.yml
+++ b/.github/workflows/clean_on_pr_closed.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   clean:
-    uses: jalantechnologies/github-ci/.github/workflows/clean.yml@v3.1
+    uses: jalantechnologies/github-ci/.github/workflows/clean.yml@v3.2
     concurrency:
       group: ci-preview-${{ github.event.pull_request.head.ref }}
       cancel-in-progress: true

--- a/.github/workflows/preview_on_dispatch.yml
+++ b/.github/workflows/preview_on_dispatch.yml
@@ -4,7 +4,7 @@ on: workflow_dispatch
 
 jobs:
   preview:
-    uses: jalantechnologies/github-ci/.github/workflows/ci.yml@v3.1
+    uses: jalantechnologies/github-ci/.github/workflows/ci.yml@v3.2
     concurrency:
       group: ci-preview-${{ github.event.ref }}
       cancel-in-progress: true

--- a/.github/workflows/preview_on_pr_update.yml
+++ b/.github/workflows/preview_on_pr_update.yml
@@ -8,7 +8,7 @@ jobs:
   preview:
     # only run when updating an 'Open' PR
     if: github.event.pull_request.state == 'open'
-    uses: jalantechnologies/github-ci/.github/workflows/ci.yml@v3.1
+    uses: jalantechnologies/github-ci/.github/workflows/ci.yml@v3.2
     concurrency:
       group: ci-preview-${{ github.event.pull_request.head.ref }}
       cancel-in-progress: true

--- a/.github/workflows/production_on_push.yml
+++ b/.github/workflows/production_on_push.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   production:
-    uses: jalantechnologies/github-ci/.github/workflows/ci.yml@v3.1
+    uses: jalantechnologies/github-ci/.github/workflows/ci.yml@v3.2
     concurrency:
       group: ci-production-${{ github.event.ref }}
       cancel-in-progress: true


### PR DESCRIPTION
### Summary
This PR updates all GitHub Actions workflow files to reference the latest `v3.2` release of the `jalantechnologies/github-ci` reusable workflow.

### Why this change?
- To take advantage of recent enhancements introduced in `v3.2`, including:
  - Improved dashboard URL formatting
  - Additional inputs like `hosting_provider` and environment-specific configs
  - General improvements and consistency across environments

### Impact
- All CI/CD pipelines (preview, production, cleanup) will now use the updated logic and configurations from `v3.2`
- Ensures compatibility with the latest deployment patterns and dashboard formatting