### PR TITLE
fix : upgrade Docker base image to Ubuntu 22.04 for pipenv issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 ARG DEBIAN_FRONTEND=noninteractive
 
 WORKDIR /app


### PR DESCRIPTION
**Why these changes require**
The Docker build was failing at the step pipenv install --dev due to Python 3.12 not being available in the base image (Ubuntu 20.04). Pipenv requires Python 3.12, and without a version manager like pyenv or asdf, it cannot auto-install it.

**What changes were done**

Updated the FROM ubuntu:20.04 line in the Dockerfile to FROM ubuntu:22.04.Verified that pipenv install --dev now completes successfully without errors.